### PR TITLE
adding button identifiers for pico remote PJ2-3B

### DIFF
--- a/src/lutron-accessory.js
+++ b/src/lutron-accessory.js
@@ -7,6 +7,7 @@ const ButtonState = {
 const ButtonMap = {
   "PICO-REMOTE": ["2", "4"],
   "PJ2-2B": ["2", "4"],
+  "PJ2-3B": ["2", "3", "4"],
   "PJ2-3BRL": ["2", "4", "5", "6", "3"]
 }
 


### PR DESCRIPTION
The PJ2-3B is a three-button Pico without Raise/Lower.

I just purchased two of these and have verified buttons 2,3,4 work in my setup.