### PR TITLE
Don’t npmignore the 'src' directory, since that’s where modules required at runtime live

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,3 @@ __tests__
 .github
 coverage
 node_modules
-src


### PR DESCRIPTION
Fixes #21 