### PR TITLE
Fix 'main' and 'types' paths in 'package.json'

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "jest"


### PR DESCRIPTION
`dist` has a flat directory structure, so don’t reference a non-existent directory named `src` allegedly inside it