### PR TITLE
Use CommonJS instead of ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "files": [
     "dist"
   ],
-  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -35,7 +34,7 @@
   "homepage": "https://github.com/smockle/homebridge-lutron-caseta#readme",
   "engines": {
     "homebridge": "^1.0.0",
-    "node": ">=12.0.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "homebridge": "^1.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Related to #43, specifically https://github.com/smockle/homebridge-lutron-caseta/issues/43#issuecomment-621576998

It looks like `homebridge` does not support importing ES Modules. Switching back to CommonJS. This also drops the Node.js requirement back down to `10.x`.